### PR TITLE
Add worklog support to the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ $ jira issue move ISSUE-1 "In Progress" --comment "Started working on it"
 $ jira issue move ISSUE-1 Done -RFixed -a$(jira me)
 ```
 
-To transition the selected issue from the TUI, press `m`.
+To transition the selected issue from the TUI, press `m`. To log work for the selected issue, press `w`.
 
 #### View
 The `view` command lets you see issue details in a terminal. Atlassian document is roughly converted to a markdown

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -52,6 +52,7 @@ const (
 * [yellow]CTRL + b[default] to scroll through a page upwards
 * [yellow]v[default] to view selected issue details
 * [yellow]m[default] to move/transition selected issue
+* [yellow]w[default] to log work for the selected issue
 * [yellow]CTRL + r / F5[default] to refresh the issues list
 * [yellow]ENTER[default] to open the selected issue in the browser
 * [yellow]c[default] to copy issue URL to the system clipboard

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -1,15 +1,22 @@
 package view
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/spf13/viper"
+
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira/filter/issue"
+	"github.com/ankitpokhrel/jira-cli/pkg/surveyext"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )
 
@@ -88,6 +95,7 @@ func (l *IssueList) Render() error {
 		}),
 		tui.WithCopyFunc(copyURL(l.Server)),
 		tui.WithCopyKeyFunc(copyKey()),
+		tui.WithWorklogFunc(logWork(l.Server)),
 		tui.WithMoveFunc(func(r, c int) func() (string, []string, tui.MoveHandlerFunc, string, tui.RefreshTableStateFunc) {
 			dataFn := func() (string, []string, tui.MoveHandlerFunc, string, tui.RefreshTableStateFunc) {
 				key := data[r][data.GetIndex(fieldKey)]
@@ -235,4 +243,115 @@ func (l *IssueList) assignColumns(columns []string, issue *jira.Issue) []string 
 	}
 
 	return bucket
+}
+
+func logWork(server string) tui.WorklogFunc {
+	return func(r, _ int, d any) tui.WorklogHandlerFunc {
+		key := issueKeyFromTuiData(r, d)
+		if key == "" {
+			return nil
+		}
+
+		return func() error {
+			fmt.Printf("\nLogging work for issue %s\n\n", key)
+
+			var timeSpent string
+			stop, err := handlePromptError(survey.AskOne(&survey.Input{
+				Message: "Time spent",
+				Help:    "Time to log as days (d), hours (h), or minutes (m), separated by space eg: 2d 1h 30m",
+			}, &timeSpent, survey.WithValidator(survey.Required)))
+			if err != nil || stop {
+				return err
+			}
+
+			var started string
+			stop, err = handlePromptError(survey.AskOne(&survey.Input{
+				Message: "Started (optional)",
+				Help:    "Datetime when the work started, eg: 2022-01-01 09:30:00 or 2022-01-01T09:30:00.000+0200",
+			}, &started))
+			if err != nil || stop {
+				return err
+			}
+
+			started = strings.TrimSpace(started)
+
+			timezone := ""
+			if started != "" {
+				defaultTimezone := viper.GetString("timezone")
+				if defaultTimezone == "" {
+					defaultTimezone = "UTC"
+				}
+
+				timezone = defaultTimezone
+
+				stop, err = handlePromptError(survey.AskOne(&survey.Input{
+					Message: "Timezone",
+					Help:    "Timezone in IANA format used when start date is provided, eg: Europe/Berlin",
+					Default: defaultTimezone,
+				}, &timezone))
+				if err != nil || stop {
+					return err
+				}
+			}
+
+			var newEstimate string
+			stop, err = handlePromptError(survey.AskOne(&survey.Input{
+				Message: "New estimate (optional)",
+				Help:    "Set a new remaining estimate, eg: 3h 30m",
+			}, &newEstimate))
+			if err != nil || stop {
+				return err
+			}
+
+			var comment string
+			stop, err = handlePromptError(survey.AskOne(&surveyext.JiraEditor{
+				Editor: &survey.Editor{
+					Message:       "Comment",
+					HideDefault:   true,
+					AppendDefault: true,
+				},
+				BlankAllowed: true,
+			}, &comment))
+			if err != nil || stop {
+				return err
+			}
+
+			timeSpent = strings.TrimSpace(timeSpent)
+			comment = strings.TrimSpace(comment)
+			newEstimate = strings.TrimSpace(newEstimate)
+
+			if started != "" {
+				formatted, ferr := cmdutil.DateStringToJiraFormatInLocation(started, strings.TrimSpace(timezone))
+				if ferr != nil {
+					cmdutil.Fail("Failed to parse start date: %s", ferr)
+					return ferr
+				}
+				started = formatted
+			}
+
+			client := api.DefaultClient(false)
+			if err := client.AddIssueWorklog(key, started, timeSpent, comment, newEstimate); err != nil {
+				cmdutil.Fail("Failed to add worklog: %s", err)
+				return err
+			}
+
+			cmdutil.Success("Worklog added to issue %q", key)
+			fmt.Printf("%s\n", cmdutil.GenerateServerBrowseURL(server, key))
+
+			return nil
+		}
+	}
+}
+
+func handlePromptError(err error) (bool, error) {
+	if err == nil {
+		return false, nil
+	}
+
+	if errors.Is(err, terminal.InterruptErr) {
+		cmdutil.Fail("Action aborted")
+		return true, nil
+	}
+
+	return false, err
 }

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -36,6 +36,12 @@ type MoveHandlerFunc func(state string) error
 // MoveFunc is fired when a user press 'm' character in the table cell.
 type MoveFunc func(row, col int) func() (key string, actions []string, handler MoveHandlerFunc, status string, refresh RefreshTableStateFunc)
 
+// WorklogHandlerFunc is a handler for worklog action.
+type WorklogHandlerFunc func() error
+
+// WorklogFunc is fired when a user press 'w' character in the table cell.
+type WorklogFunc func(row, col int, data interface{}) WorklogHandlerFunc
+
 // CopyFunc is fired when a user press 'c' character in the table cell.
 type CopyFunc func(row, column int, data interface{})
 
@@ -99,6 +105,7 @@ type Table struct {
 	selectedFunc SelectedFunc
 	viewModeFunc ViewModeFunc
 	moveFunc     MoveFunc
+	worklogFunc  WorklogFunc
 	refreshFunc  RefreshFunc
 	copyFunc     CopyFunc
 	copyKeyFunc  CopyKeyFunc
@@ -190,6 +197,13 @@ func WithViewModeFunc(fn ViewModeFunc) TableOption {
 func WithMoveFunc(fn MoveFunc) TableOption {
 	return func(t *Table) {
 		t.moveFunc = fn
+	}
+}
+
+// WithWorklogFunc sets a func that is triggered when a user press 'w'.
+func WithWorklogFunc(fn WorklogFunc) TableOption {
+	return func(t *Table) {
+		t.worklogFunc = fn
 	}
 }
 
@@ -378,6 +392,31 @@ func (t *Table) initTable() {
 						}()
 
 						// Refresh the screen.
+						t.screen.Draw()
+					}()
+				case 'w':
+					if t.worklogFunc == nil {
+						break
+					}
+
+					r, c := t.view.GetSelection()
+					handler := t.worklogFunc(r, c, t.data)
+					if handler == nil {
+						break
+					}
+
+					go func() {
+						var err error
+						t.screen.Suspend(func() {
+							err = handler()
+						})
+						if err != nil {
+							// Errors are reported by the handler itself. We redraw the
+							// screen to ensure the UI state is refreshed before
+							// returning to the table view.
+							t.screen.Draw()
+							return
+						}
 						t.screen.Draw()
 					}()
 				}


### PR DESCRIPTION
## Summary
- add a worklog handler to the TUI table so users can press `w` to log time from issue lists
- prompt for time spent, dates, and comments before sending the worklog to Jira
- document the new shortcut in the in-app help and README

## Testing
- PAGER=cat go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d68f37a7808329bb686c41dd85ca31