### PR TITLE
Fix import block formatting in issues view

### DIFF
--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"s
+	"os"
 	"strings"
 	"text/tabwriter"
-
 
 	"github.com/spf13/viper"
 


### PR DESCRIPTION
## Summary
- remove the stray characters in the `internal/view/issues.go` import block
- run `gofmt` to normalize the import list

## Testing
- make ci *(fails: golangci-lint reports "unsupported version of the configuration: \"\"")*


------
https://chatgpt.com/codex/tasks/task_e_68d69e4bf7748329824d918eebce19e8