### PR TITLE
Remove unused imports from issues view

### DIFF
--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -1,13 +1,11 @@
 package view
 
 import (
-	"errors"
 	"fmt"
 	"io"
-	"os"s
+	"os"
 	"strings"
 	"text/tabwriter"
-
 
 	"github.com/spf13/viper"
 
@@ -15,7 +13,6 @@ import (
 	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira/filter/issue"
-	"github.com/ankitpokhrel/jira-cli/pkg/surveyext"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
 )
 


### PR DESCRIPTION
## Summary
- remove the unused `errors` and `surveyext` imports from `internal/view/issues.go`
- re-run gofmt to keep the import block tidy

## Testing
- make ci *(fails: golangci-lint reports "unsupported version of the configuration: \"\"")*


------
https://chatgpt.com/codex/tasks/task_e_68d69e4bf7748329824d918eebce19e8