### PR TITLE
Keep worklog entry within the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The lists are displayed in an interactive UI by default.
 - Use `CTRL + b` to scroll through a page in upwards direction.
 - Press `v` to view selected issue details.
 - Press `m` to transition the selected issue.
+- Press `w` to add a worklog to the selected issue.
 - Press `CTRL + r` or `F5` to refresh the issues list.
 - Hit `ENTER` to open the selected issue in the browser.
 - Press `c` to copy issue URL to the system clipboard. This requires `xclip` / `xsel` in linux.

--- a/internal/view/helper.go
+++ b/internal/view/helper.go
@@ -52,6 +52,7 @@ const (
 * [yellow]CTRL + b[default] to scroll through a page upwards
 * [yellow]v[default] to view selected issue details
 * [yellow]m[default] to move/transition selected issue
+* [yellow]w[default] to add a worklog to the selected issue
 * [yellow]CTRL + r / F5[default] to refresh the issues list
 * [yellow]ENTER[default] to open the selected issue in the browser
 * [yellow]c[default] to copy issue URL to the system clipboard

--- a/internal/view/issues.go
+++ b/internal/view/issues.go
@@ -8,9 +8,11 @@ import (
 	"text/tabwriter"
 
 	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira"
 	"github.com/ankitpokhrel/jira-cli/pkg/jira/filter/issue"
 	"github.com/ankitpokhrel/jira-cli/pkg/tui"
+	"github.com/spf13/viper"
 )
 
 // DisplayFormat is a issue display type.
@@ -127,6 +129,32 @@ func (l *IssueList) Render() error {
 				}
 			}
 			return dataFn
+		}),
+		tui.WithWorklogFunc(func(r, c int) func() *tui.WorklogForm {
+			return func() *tui.WorklogForm {
+				key := data[r][data.GetIndex(fieldKey)]
+				if key == "" {
+					return nil
+				}
+
+				client := api.DefaultClient(false)
+				server := viper.GetString("server")
+
+				return &tui.WorklogForm{
+					Key: key,
+					Submit: func(timeSpent, comment string) (tui.WorklogResult, error) {
+						if err := client.AddIssueWorklog(key, "", timeSpent, comment, ""); err != nil {
+							return tui.WorklogResult{}, fmt.Errorf("%s", cmdutil.NormalizeJiraError(err.Error()))
+						}
+
+						url := cmdutil.GenerateServerBrowseURL(server, key)
+						return tui.WorklogResult{
+							Message: fmt.Sprintf("Worklog added to issue %s", key),
+							URL:     url,
+						}, nil
+					},
+				}
+			}
 		}),
 		tui.WithRefreshFunc(l.Refresh),
 		tui.WithFixedColumns(l.Display.FixedColumns),

--- a/pkg/tui/primitive/actionmodal.go
+++ b/pkg/tui/primitive/actionmodal.go
@@ -70,6 +70,11 @@ func (m *ActionModal) GetFooter() *tview.TextView {
 	return m.footer
 }
 
+// GetForm returns the form embedded in the modal.
+func (m *ActionModal) GetForm() *tview.Form {
+	return m.form
+}
+
 // SetBackgroundColor sets the color of the modal frame background.
 func (m *ActionModal) SetBackgroundColor(color tcell.Color) *ActionModal {
 	m.form.SetBackgroundColor(color)

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -12,8 +12,14 @@ import (
 )
 
 const (
-	defaultColPad   = 1
-	defaultColWidth = 80
+	defaultColPad           = 1
+	defaultColWidth         = 80
+	worklogSubmitButton     = "Submit"
+	worklogCancelButton     = "Cancel"
+	worklogDoneButton       = "Done"
+	worklogFooterHint       = "Use TAB or ← → to navigate fields, ENTER to submit."
+	worklogFooterProcessing = "Processing. Please wait..."
+	worklogFooterReturn     = "Press ENTER or ESC to return to the issues list."
 )
 
 var errNoData = fmt.Errorf("no data")
@@ -35,6 +41,26 @@ type MoveHandlerFunc func(state string) error
 
 // MoveFunc is fired when a user press 'm' character in the table cell.
 type MoveFunc func(row, col int) func() (key string, actions []string, handler MoveHandlerFunc, status string, refresh RefreshTableStateFunc)
+
+// WorklogFunc is fired when a user press 'w' character in the table cell.
+type WorklogFunc func(row, col int) func() *WorklogForm
+
+// WorklogForm represents the data required to render a worklog modal.
+type WorklogForm struct {
+	Key              string
+	DefaultTimeSpent string
+	DefaultComment   string
+	Submit           WorklogSubmitFunc
+}
+
+// WorklogSubmitFunc processes a worklog submission.
+type WorklogSubmitFunc func(timeSpent, comment string) (WorklogResult, error)
+
+// WorklogResult describes the outcome of a worklog submission.
+type WorklogResult struct {
+	Message string
+	URL     string
+}
 
 // CopyFunc is fired when a user press 'c' character in the table cell.
 type CopyFunc func(row, column int, data interface{})
@@ -102,6 +128,7 @@ type Table struct {
 	refreshFunc  RefreshFunc
 	copyFunc     CopyFunc
 	copyKeyFunc  CopyKeyFunc
+	worklogFunc  WorklogFunc
 }
 
 // TableOption is a functional option to wrap table properties.
@@ -190,6 +217,13 @@ func WithViewModeFunc(fn ViewModeFunc) TableOption {
 func WithMoveFunc(fn MoveFunc) TableOption {
 	return func(t *Table) {
 		t.moveFunc = fn
+	}
+}
+
+// WithWorklogFunc sets a func that is triggered when a user press 'w'.
+func WithWorklogFunc(fn WorklogFunc) TableOption {
+	return func(t *Table) {
+		t.worklogFunc = fn
 	}
 }
 
@@ -374,6 +408,107 @@ func (t *Table) initTable() {
 									refreshFunc(r, c, btnLabel)
 									_ = t.Paint(t.data)
 								}
+							})
+						}()
+
+						// Refresh the screen.
+						t.screen.Draw()
+					}()
+				case 'w':
+					if t.worklogFunc == nil {
+						break
+					}
+
+					go func() {
+						var showAction bool
+
+						func() {
+							t.painter.ShowPage("secondary").SendToFront("secondary")
+							defer func() {
+								t.painter.HidePage("secondary")
+								if showAction {
+									t.painter.ShowPage("action")
+								}
+							}()
+
+							r, c := t.view.GetSelection()
+							resolver := t.worklogFunc(r, c)
+							if resolver == nil {
+								return
+							}
+
+							worklog := resolver()
+							if worklog == nil || worklog.Key == "" || worklog.Submit == nil {
+								return
+							}
+
+							form := t.action.GetForm()
+							form.Clear(true)
+
+							t.action.SetText(fmt.Sprintf("Add a worklog to %s", worklog.Key))
+
+							form.AddInputField("Time spent", worklog.DefaultTimeSpent, 20, nil, nil)
+							form.AddTextArea("Comment", worklog.DefaultComment, 0, 5, 0, nil)
+
+							timeItem, _ := form.GetFormItem(0).(*tview.InputField)
+							commentItem, _ := form.GetFormItem(1).(*tview.TextArea)
+							if commentItem != nil {
+								commentItem.SetPlaceholder("Optional comment")
+							}
+
+							t.action.ClearButtons().AddButtons([]string{worklogSubmitButton, worklogCancelButton})
+							form.SetFocus(0)
+							t.action.GetFooter().SetText(worklogFooterHint).SetTextColor(tcell.ColorGray)
+
+							showAction = true
+
+							t.action.SetDoneFunc(func(btnIndex int, btnLabel string) {
+								if btnIndex < 0 || btnLabel == worklogCancelButton {
+									t.painter.HidePage("action")
+									return
+								}
+
+								if btnLabel != worklogSubmitButton {
+									return
+								}
+
+								if timeItem == nil {
+									return
+								}
+
+								timeSpent := strings.TrimSpace(timeItem.GetText())
+								if timeSpent == "" {
+									t.action.GetFooter().SetText("Time spent is required.").SetTextColor(tcell.ColorRed)
+									return
+								}
+
+								comment := ""
+								if commentItem != nil {
+									comment = commentItem.GetText()
+								}
+
+								t.action.GetFooter().SetText(worklogFooterProcessing).SetTextColor(tcell.ColorGray)
+								t.screen.ForceDraw()
+
+								result, err := worklog.Submit(timeSpent, comment)
+								if err != nil {
+									t.action.GetFooter().SetText(fmt.Sprintf("Error: %s", err.Error())).SetTextColor(tcell.ColorRed)
+									return
+								}
+
+								message := result.Message
+								if result.URL != "" {
+									message = fmt.Sprintf("%s\n%s", message, result.URL)
+								}
+
+								form.Clear(true)
+								t.action.ClearButtons().AddButtons([]string{worklogDoneButton})
+								t.action.SetText(message)
+								t.action.GetFooter().SetText(worklogFooterReturn).SetTextColor(tcell.ColorGray)
+
+								t.action.SetDoneFunc(func(int, string) {
+									t.painter.HidePage("action")
+								})
 							})
 						}()
 

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -166,7 +166,10 @@ func NewTable(opts ...TableOption) *Table {
 
 	tbl.action.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
 		if ev.Key() == tcell.KeyEsc || (ev.Key() == tcell.KeyRune && ev.Rune() == 'q') {
-			tbl.painter.HidePage("action")
+			tbl.screen.QueueUpdateDraw(func() {
+				tbl.painter.HidePage("action")
+				tbl.screen.SetFocus(tbl.view)
+			})
 		}
 		return ev
 	})
@@ -424,6 +427,18 @@ func (t *Table) initTable() {
 					go func() {
 						var showAction bool
 
+						closeAction := func() {
+							if !showAction {
+								return
+							}
+
+							showAction = false
+							t.screen.QueueUpdateDraw(func() {
+								t.painter.HidePage("action")
+								t.screen.SetFocus(t.view)
+							})
+						}
+
 						func() {
 							t.painter.ShowPage("secondary").SendToFront("secondary")
 							defer func() {
@@ -479,8 +494,7 @@ func (t *Table) initTable() {
 
 							t.action.SetDoneFunc(func(btnIndex int, btnLabel string) {
 								if btnIndex < 0 || btnLabel == worklogCancelButton {
-									showAction = false
-									t.painter.HidePage("action")
+									closeAction()
 									return
 								}
 
@@ -518,13 +532,13 @@ func (t *Table) initTable() {
 								}
 
 								form.Clear(true)
-								t.action.ClearButtons().AddButtons([]string{worklogDoneButton}).SetFocus(0)
+								t.action.ClearButtons().AddButtons([]string{worklogDoneButton})
+								form.SetFocus(form.GetFormItemCount())
 								t.action.SetText(message)
 								t.action.GetFooter().SetText(worklogFooterReturn).SetTextColor(tcell.ColorGray)
 
 								t.action.SetDoneFunc(func(int, string) {
-									showAction = false
-									t.painter.HidePage("action")
+									closeAction()
 								})
 							})
 						}()

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -16,10 +16,8 @@ const (
 	defaultColWidth            = 80
 	worklogSubmitButton        = "Submit"
 	worklogCancelButton        = "Cancel"
-	worklogDoneButton          = "Done"
 	worklogFooterHint          = "Use TAB or ← → to navigate fields, ENTER to submit."
 	worklogFooterProcessing    = "Processing. Please wait..."
-	worklogFooterReturn        = "Press ENTER or ESC to return to the issues list."
 	worklogTimeSpentFieldWidth = 20
 	worklogCommentFieldHeight  = 5
 )
@@ -526,20 +524,20 @@ func (t *Table) initTable() {
 									return
 								}
 
-								message := result.Message
+								footerMessage := result.Message
 								if result.URL != "" {
-									message = fmt.Sprintf("%s\n%s", message, result.URL)
+									footerMessage = fmt.Sprintf("%s • %s", footerMessage, result.URL)
 								}
 
 								form.Clear(true)
-								t.action.ClearButtons().AddButtons([]string{worklogDoneButton})
-								form.SetFocus(form.GetFormItemCount())
-								t.action.SetText(message)
-								t.action.GetFooter().SetText(worklogFooterReturn).SetTextColor(tcell.ColorGray)
 
-								t.action.SetDoneFunc(func(int, string) {
-									closeAction()
-								})
+								if footerMessage != "" {
+									t.screen.QueueUpdateDraw(func() {
+										t.footer.SetText(pad(fmt.Sprintf("%s\n%s", t.footerText, footerMessage), 1))
+									})
+								}
+
+								closeAction()
 							})
 						}()
 

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -477,9 +477,10 @@ func (t *Table) initTable() {
 
 							showAction = true
 
-							t.action.SetDoneFunc(func(btnIndex int, btnLabel string) {
-								if btnIndex < 0 || btnLabel == worklogCancelButton {
-									t.painter.HidePage("action")
+                                                        t.action.SetDoneFunc(func(btnIndex int, btnLabel string) {
+                                                                if btnIndex < 0 || btnLabel == worklogCancelButton {
+                                                                        showAction = false
+                                                                        t.painter.HidePage("action")
 									return
 								}
 
@@ -521,10 +522,11 @@ func (t *Table) initTable() {
 								t.action.SetText(message)
 								t.action.GetFooter().SetText(worklogFooterReturn).SetTextColor(tcell.ColorGray)
 
-								t.action.SetDoneFunc(func(int, string) {
-									t.painter.HidePage("action")
-								})
-							})
+                                                                t.action.SetDoneFunc(func(int, string) {
+                                                                        showAction = false
+                                                                        t.painter.HidePage("action")
+                                                                })
+                                                        })
 						}()
 
 						// Refresh the screen.

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -445,7 +445,10 @@ func (t *Table) initTable() {
 							}
 
 							form := t.action.GetForm()
-							form.Clear(true)
+							form.Clear(true).
+								SetFieldBackgroundColor(tcell.ColorSpecial).
+								SetFieldTextColor(tcell.ColorDefault).
+								SetLabelColor(tcell.ColorDefault)
 
 							t.action.SetText(fmt.Sprintf("Add a worklog to %s", worklog.Key))
 
@@ -453,9 +456,19 @@ func (t *Table) initTable() {
 							form.AddTextArea("Comment", worklog.DefaultComment, 0, worklogCommentFieldHeight, 0, nil)
 
 							timeItem, _ := form.GetFormItem(0).(*tview.InputField)
+							if timeItem != nil {
+								timeItem.SetFieldBackgroundColor(tcell.ColorSpecial).
+									SetFieldTextColor(tcell.ColorDefault).
+									SetBackgroundColor(tcell.ColorSpecial)
+							}
+
 							commentItem, _ := form.GetFormItem(1).(*tview.TextArea)
 							if commentItem != nil {
-								commentItem.SetPlaceholder("Optional comment")
+								commentItem.SetPlaceholder("Optional comment").
+									SetPlaceholderStyle(tcell.StyleDefault.Foreground(tcell.ColorGray)).
+									SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorDefault))
+
+								commentItem.SetBackgroundColor(tcell.ColorSpecial)
 							}
 
 							t.action.ClearButtons().AddButtons([]string{worklogSubmitButton, worklogCancelButton})

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -12,14 +12,16 @@ import (
 )
 
 const (
-	defaultColPad           = 1
-	defaultColWidth         = 80
-	worklogSubmitButton     = "Submit"
-	worklogCancelButton     = "Cancel"
-	worklogDoneButton       = "Done"
-	worklogFooterHint       = "Use TAB or ← → to navigate fields, ENTER to submit."
-	worklogFooterProcessing = "Processing. Please wait..."
-	worklogFooterReturn     = "Press ENTER or ESC to return to the issues list."
+	defaultColPad              = 1
+	defaultColWidth            = 80
+	worklogSubmitButton        = "Submit"
+	worklogCancelButton        = "Cancel"
+	worklogDoneButton          = "Done"
+	worklogFooterHint          = "Use TAB or ← → to navigate fields, ENTER to submit."
+	worklogFooterProcessing    = "Processing. Please wait..."
+	worklogFooterReturn        = "Press ENTER or ESC to return to the issues list."
+	worklogTimeSpentFieldWidth = 20
+	worklogCommentFieldHeight  = 5
 )
 
 var errNoData = fmt.Errorf("no data")
@@ -447,8 +449,8 @@ func (t *Table) initTable() {
 
 							t.action.SetText(fmt.Sprintf("Add a worklog to %s", worklog.Key))
 
-							form.AddInputField("Time spent", worklog.DefaultTimeSpent, 20, nil, nil)
-							form.AddTextArea("Comment", worklog.DefaultComment, 0, 5, 0, nil)
+							form.AddInputField("Time spent", worklog.DefaultTimeSpent, worklogTimeSpentFieldWidth, nil, nil)
+							form.AddTextArea("Comment", worklog.DefaultComment, 0, worklogCommentFieldHeight, 0, nil)
 
 							timeItem, _ := form.GetFormItem(0).(*tview.InputField)
 							commentItem, _ := form.GetFormItem(1).(*tview.TextArea)

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -477,10 +477,10 @@ func (t *Table) initTable() {
 
 							showAction = true
 
-                                                        t.action.SetDoneFunc(func(btnIndex int, btnLabel string) {
-                                                                if btnIndex < 0 || btnLabel == worklogCancelButton {
-                                                                        showAction = false
-                                                                        t.painter.HidePage("action")
+							t.action.SetDoneFunc(func(btnIndex int, btnLabel string) {
+								if btnIndex < 0 || btnLabel == worklogCancelButton {
+									showAction = false
+									t.painter.HidePage("action")
 									return
 								}
 
@@ -522,11 +522,11 @@ func (t *Table) initTable() {
 								t.action.SetText(message)
 								t.action.GetFooter().SetText(worklogFooterReturn).SetTextColor(tcell.ColorGray)
 
-                                                                t.action.SetDoneFunc(func(int, string) {
-                                                                        showAction = false
-                                                                        t.painter.HidePage("action")
-                                                                })
-                                                        })
+								t.action.SetDoneFunc(func(int, string) {
+									showAction = false
+									t.painter.HidePage("action")
+								})
+							})
 						}()
 
 						// Refresh the screen.

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -517,7 +517,7 @@ func (t *Table) initTable() {
 								}
 
 								form.Clear(true)
-								t.action.ClearButtons().AddButtons([]string{worklogDoneButton})
+								t.action.ClearButtons().AddButtons([]string{worklogDoneButton}).SetFocus(0)
 								t.action.SetText(message)
 								t.action.GetFooter().SetText(worklogFooterReturn).SetTextColor(tcell.ColorGray)
 


### PR DESCRIPTION
## Summary
- replace the suspended survey-based flow with an in-TUI worklog modal that captures input without leaving the table
- expose the action modal form so the table can collect worklog details and show success feedback inline
- simplify the issue list handler to return a worklog submission callback that posts to Jira while staying inside the overlay

## Testing
- go test ./... *(fails: exec "less": executable file not found in $PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bc6bf78483298af73b6f0a84f6cd